### PR TITLE
Add corename targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,12 @@
 SIM_DIR := hardware/simulation/icarus
 
+corename:
+	@echo "MUL"
+
 sim:
 	make -C $(SIM_DIR)
 
 clean:
 	make -C $(SIM_DIR) clean
 
-.PHONY: sim clean
+.PHONY: corename sim clean

--- a/hardware/hardware.mk
+++ b/hardware/hardware.mk
@@ -1,0 +1,2 @@
+#add itself to MODULES list
+MODULES+=$(shell make -C $(MUL_DIR) corename | grep -v make)


### PR DESCRIPTION
- Add `corename` target in top level makefile
- Add `hardware/hardware.mk` makefile for `MODULES` addition